### PR TITLE
feat: add Leaflet map integration to property detail page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,9 @@
     "requires": true,
     "packages": {
         "": {
+            "dependencies": {
+                "leaflet": "^1.9.4"
+            },
             "devDependencies": {
                 "@tailwindcss/vite": "^4.0.0",
                 "@vitejs/plugin-vue": "^6.0.0",
@@ -1865,6 +1868,12 @@
             "peerDependencies": {
                 "vite": "^5.0.0 || ^6.0.0"
             }
+        },
+        "node_modules/leaflet": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+            "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+            "license": "BSD-2-Clause"
         },
         "node_modules/lightningcss": {
             "version": "1.30.1",

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
         "tailwindcss": "^4.0.0",
         "vite": "^6.2.4",
         "vue": "^3.5.17"
+    },
+    "dependencies": {
+        "leaflet": "^1.9.4"
     }
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,3 +1,4 @@
+import "leaflet/dist/leaflet.css";
 import { createApp } from "vue";
 import "./bootstrap";
 import PropertyMap from "./components/PropertyMap.vue";

--- a/resources/js/components/PropertyMap.vue
+++ b/resources/js/components/PropertyMap.vue
@@ -3,9 +3,25 @@
 </template>
 
 <script setup>
+import L from "leaflet";
 import { onMounted } from "vue";
 
+const props = defineProps({
+    lat: {
+        type: Number,
+        required: true,
+    },
+    lng: {
+        type: Number,
+        required: true,
+    },
+});
+
 onMounted(() => {
-    // Google Maps API 読み込み後に地図を描画する処理をここに書く
+    const map = L.map("map").setView([props.lat, props.lng], 15);
+    L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+        attribution: "&copy; OpenStreetMap contributors",
+    }).addTo(map);
+    L.marker([props.lat, props.lng]).addTo(map);
 });
 </script>

--- a/resources/views/properties/show.blade.php
+++ b/resources/views/properties/show.blade.php
@@ -3,6 +3,6 @@
 @section('content')
     <h1>{{ $property->name }}</h1>
     <div id="vue-property-map">
-        <property-map></property-map>
+        <property-map :lat="{{ property->latitude }}" :lng="{{ $property->longitude }}"></property-map>
     </div>
 @endsection


### PR DESCRIPTION
以下の変更を行い、物件詳細ページでLeafletを使った地図表示を実装しました。

1. Leafletパッケージのインストールと依存関係の追加（npm install）
2. ViteでLeafletのCSSを読み込み設定
3. Vueコンポーネント（PropertyMap.vue）でLeafletを利用した地図描画機能を追加
4. Bladeテンプレート（show.blade.php）でVueコンポーネントを呼び出し、物件の緯度・経度を渡す実装
5. Vueアプリのマウント設定をapp.jsで更新し、LeafletのCSSインポートも追加

これにより、物件の位置を動的に表示できるようになり、ユーザビリティが向上します。
