### PR TITLE
feat: add initial database migrations, models, and seeders for Property and Agent

### DIFF
--- a/app/Models/Agent.php
+++ b/app/Models/Agent.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Agent extends Model
+{
+    public function properties()
+    {
+        return $this->bolongToMany(property::class, 'property_agent');
+    }
+}

--- a/app/Models/Property.php
+++ b/app/Models/Property.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Property extends Model
+{
+    public function agents()
+    {
+        return $this->belongsToMany(Agent::class, 'property_agent');
+    }
+}

--- a/database/migrations/2025_07_16_053535_create_properties_table.php
+++ b/database/migrations/2025_07_16_053535_create_properties_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('properties', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('address')->nullable();
+            $table->decimal('latitude', 10, 7)->nullable();
+            $table->decimal('longitude', 10, 7)->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('properties');
+    }
+};

--- a/database/migrations/2025_07_16_053946_create_agents_table.php
+++ b/database/migrations/2025_07_16_053946_create_agents_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('agents', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('agents');
+    }
+};

--- a/database/migrations/2025_07_16_054109_create_property_agent_table.php
+++ b/database/migrations/2025_07_16_054109_create_property_agent_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('property_agent', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('property_id')->constrained()->onDelete('cascade');
+            $table->foreignId('agent_id')->constrained()->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('property_agent');
+    }
+};

--- a/database/seeders/PropertySeeder.php
+++ b/database/seeders/PropertySeeder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\Property;
+
+class PropertySeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Property::create([
+            'name' => 'Sample Tokyotower',
+            'address' => '東京都港区芝公園test',
+            'latitude' => '35.3931',
+            'longitude' => '139.4444',
+        ]);
+    }
+}


### PR DESCRIPTION
- 物件（properties）と担当者（agents）テーブルのマイグレーションを作成・実行
- 中間テーブル（property_agent）のマイグレーションを作成
- PropertyモデルとAgentモデルを作成
- PropertySeederを作成し、テストデータを投入できるように設定

データベースの基本構造を整え、今後の開発に向けた土台を構築しました。

