### PR TITLE
feat: implement property and agent management with assignment support

### DIFF
--- a/app/Http/Controllers/AgentController.php
+++ b/app/Http/Controllers/AgentController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Agent;
+use Illuminate\Http\Request;
+
+class AgentController extends Controller
+{
+    public function index()
+    {
+        $agents = Agent::all();
+        return view('agents.index', compact('agents'));
+    }
+
+    public function create()
+    {
+        return view('agents.create');
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'name' => 'required|string|max:255',
+            'email' => 'required|email|unique:agents,email',
+        ]);
+        Agent::create($validated);
+        return redirect()->route('agents.index')->with('success', '担当者を登録しました');
+    }
+
+    public function show(Agent $agent)
+    {
+        return view('agents.show', compact('agent'));
+    }
+
+    public function edit(Agent $agent)
+    {
+        return view('agents.edit', compact('agent'));
+    }
+
+    public function update(Request $request, Agent $agent)
+    {
+        $validated = $request->validate([
+            'name' => 'required|string|max:255',
+            'email' => 'required|email|unique:agents,email,' . $agent->id,
+        ]);
+        $agent->update($validated);
+        return redirect()->route('agents.index')->with('success', '担当者を更新しました');
+    }
+
+    public function destroy(Agent $agent)
+    {
+        $agent->delete();
+        return redirect()->route('agents.index')->with('success', '担当者を削除しました');
+    }
+}

--- a/app/Http/Controllers/PropertyAgentController.php
+++ b/app/Http/Controllers/PropertyAgentController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Property;
+use App\Models\Agent;
+
+class PropertyAgentController extends Controller
+{
+    // 担当者を物件に割り当て
+    public function assign(Request $request, Property $property)
+    {
+        $request->validate([
+            'agent_id' => 'required|exists:agents,id'
+        ]);
+        $property->agents()->syncWithoutDetaching([$request->agent_id]);
+        return response()->json(['success' => true]);
+    }
+
+    // 物件から担当者の割り当てを解除
+    public function unassign(Request $request, Property $property)
+    {
+        $request->validate([
+            'agent_id' => 'required|exists:agents,id'
+        ]);
+        $property->agents()->detach($request->agent_id);
+        return response()->json(['success' => true]);
+    }
+}

--- a/app/Http/Controllers/PropertyController.php
+++ b/app/Http/Controllers/PropertyController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Property;
+use Illuminate\Http\Request;
+
+class PropertyController extends Controller
+{
+    public function index()
+    {
+        $properties = Property::all();
+        return view('properties.index', compact('properties'));
+    }
+
+    public function create()
+    {
+        return view('properties.create');
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'name' => 'required|string|max:255',
+            'address' => 'nullable|string|max:255',
+            'latitude' => 'nullable|numeric',
+            'longitude' => 'nullable|numeric',
+        ]);
+        Property::create($validated);
+        return redirect()->route('properties.index')->with('success', '物件を登録しました');
+    }
+
+    public function show(Property $property)
+    {
+        return view('properties.show', compact('property'));
+    }
+
+    public function edit(Property $property)
+    {
+        return view('properties.edit', compact('property'));
+    }
+
+    public function update(Request $request, Property $property)
+    {
+        $validated = $request->validate([
+            'name' => 'required|string|max:255',
+            'address' => 'nullable|string|max:255',
+            'latitude' => 'nullable|numeric',
+            'longitude' => 'nullable|numeric',
+        ]);
+        $property->update($validated);
+        return redirect()->route('properties.index')->with('success', '物件を更新しました');
+    }
+
+    public function destroy(Property $property)
+    {
+        $property->delete();
+        return redirect()->route('properties.index')->with('success', '物件を削除しました');
+    }
+}

--- a/app/Models/Agent.php
+++ b/app/Models/Agent.php
@@ -6,8 +6,12 @@ use Illuminate\Database\Eloquent\Model;
 
 class Agent extends Model
 {
+    protected $fillable = [
+        'name', 'email'
+    ];
+
     public function properties()
     {
-        return $this->bolongToMany(property::class, 'property_agent');
+        return $this->belongsToMany(Property::class, 'property_agent')->withTimestamps();
     }
 }

--- a/app/Models/Property.php
+++ b/app/Models/Property.php
@@ -6,8 +6,12 @@ use Illuminate\Database\Eloquent\Model;
 
 class Property extends Model
 {
+    protected $fillable = [
+        'name', 'address', 'latitude', 'longitude'
+    ];
+
     public function agents()
     {
-        return $this->belongsToMany(Agent::class, 'property_agent');
+        return $this->belongsToMany(Agent::class, 'property_agent')->withTimestamps();
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\PropertyAgentController;
+
+// 物件と担当者の割り当て
+Route::post('/properties/{property}/assign', [PropertyAgentController::class, 'assign']);
+Route::post('/properties/{property}/unassign', [PropertyAgentController::class, 'unassign']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,16 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\PropertyController;
+use App\Http\Controllers\AgentController;
 
+// 物件一覧・登録・編集・削除
+Route::resource('properties', PropertyController::class);
+
+// 担当者一覧・登録・編集・削除
+Route::resource('agents', AgentController::class);
+
+// トップページを物件一覧にリダイレクト
 Route::get('/', function () {
-    return view('welcome');
+    return redirect()->route('properties.index');
 });


### PR DESCRIPTION
  物件（Property）および担当者（Agent）の管理機能を実装し、下記の内容を含んでいます。

- AgentController を追加し、担当者の CRUD 処理を実装
- PropertyController に物件の CRUD 処理を実装
- PropertyAgentController を追加し、物件と担当者の割り当て・解除API（assign / unassign）を実装
- Property モデルと Agent モデルに多対多リレーション（belongsToMany）を定義
- routes/web.php に Route::resource() を使って物件・担当者ルーティングを登録
- routes/api.php に割り当て・解除用APIエンドポイントを追加
 
---

### **修正**
- トップページルーティングを / → properties.index にリダイレクトするよう変更
- 一部リレーション記述ミス（bolongToMany → belongsToMany）を修正

---

この実装により、物件に対する担当者の割り当て・解除、およびそれぞれの一覧・登録・編集・削除操作が可能になります。今後の管理機能の拡張や画面との連携に向けたベースが整いました。