### PR TITLE
feat: initial setup for routing, controllers, Vue pages and Inertia integration

### DIFF
--- a/app/Http/Controllers/PropertyController.php
+++ b/app/Http/Controllers/PropertyController.php
@@ -3,19 +3,26 @@
 namespace App\Http\Controllers;
 
 use App\Models\Property;
+use App\Models\Agent;
 use Illuminate\Http\Request;
+use Inertia\Inertia;
 
 class PropertyController extends Controller
 {
     public function index()
     {
-        $properties = Property::all();
-        return view('properties.index', compact('properties'));
+        $properties = Property::with('agents')->get();
+        return Inertia::render('Properties/Index', [
+            'properties' => $properties,
+        ]);
     }
 
     public function create()
     {
-        return view('properties.create');
+        $agents = Agent::all();
+        return Inertia::render('Properties/Create', [
+            'agents' => $agents,
+        ]);
     }
 
     public function store(Request $request)
@@ -32,12 +39,19 @@ class PropertyController extends Controller
 
     public function show(Property $property)
     {
-        return view('properties.show', compact('property'));
+        $property->load('agents');
+        return Inertia::render('Properties/Show', [
+            'property' => $property,
+        ]);
     }
 
     public function edit(Property $property)
     {
-        return view('properties.edit', compact('property'));
+        $agents = Agent::all();
+        return Inertia::render('Properties/Edit', [
+            'property' => $property,
+            'agents' => $agents,
+        ]);
     }
 
     public function update(Request $request, Property $property)

--- a/resources/js/Pages/Properties/Show.vue
+++ b/resources/js/Pages/Properties/Show.vue
@@ -1,0 +1,26 @@
+<script setup>
+import { Link } from "@inertiajs/inertia-vue3";
+import PropertyMap from "../../Components/PropertyMap.vue";
+defineProps({ property: Object });
+</script>
+
+<template>
+    <div>
+        <h2>{{ property.name }}</h2>
+        <p>住所: {{ property.address }}</p>
+        <p>緯度: {{ property.latitude }}, 経度: {{ property.longitude }}</p>
+        <PropertyMap
+            v-if="property.latitude && property.longitude"
+            :lat="property.latitude"
+            :lng="property.longitude"
+        />
+
+        <h3>担当者</h3>
+        <ul>
+            <li v-for="agent in property.agents" :key="agent.id">
+                {{ agent.name }}
+            </li>
+        </ul>
+        <Link href="/properties">一覧へ戻る</Link>
+    </div>
+</template>

--- a/resources/js/Pages/Properties/index.vue
+++ b/resources/js/Pages/Properties/index.vue
@@ -1,0 +1,24 @@
+<script setup>
+import { Link } from "@inertiajs/inertia-vue3";
+defineProps({ properties: Array });
+</script>
+
+<template>
+    <div>
+        <h1>物件一覧</h1>
+        <Link href="/properties/create" class="btn btn-primary"
+            >新規物件登録</Link
+        >
+        <ul>
+            <li v-for="property in properties" :key="property.id">
+                <Link :href="`/properties/${property.id}`">{{
+                    property.name
+                }}</Link>
+                <span
+                    >担当者:
+                    {{ property.agents.map((a) => a.name).join(", ") }}</span
+                >
+            </li>
+        </ul>
+    </div>
+</template>

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,27 +1,11 @@
-import '../css/app.css';
-import './bootstrap';
-
-import { createInertiaApp } from '@inertiajs/vue3';
-import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
-import { createApp, h } from 'vue';
-import { ZiggyVue } from '../../vendor/tightenco/ziggy';
-
-const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
+import { createInertiaApp } from "@inertiajs/inertia-vue3";
+import { createApp, h } from "vue";
 
 createInertiaApp({
-    title: (title) => `${title} - ${appName}`,
-    resolve: (name) =>
-        resolvePageComponent(
-            `./Pages/${name}.vue`,
-            import.meta.glob('./Pages/**/*.vue'),
-        ),
+    resolve: (name) => require(`./Pages/${name}.vue`),
     setup({ el, App, props, plugin }) {
-        return createApp({ render: () => h(App, props) })
+        createApp({ render: () => h(App, props) })
             .use(plugin)
-            .use(ZiggyVue)
             .mount(el);
-    },
-    progress: {
-        color: '#4B5563',
     },
 });

--- a/resources/js/components/PropertyMap.vue
+++ b/resources/js/components/PropertyMap.vue
@@ -1,27 +1,19 @@
 <template>
-    <div id="map" style="height: 400px"></div>
+    <div ref="map" style="height: 400px"></div>
 </template>
 
 <script setup>
 import L from "leaflet";
-import { onMounted } from "vue";
+import { onMounted, ref } from "vue";
 
-const props = defineProps({
-    lat: {
-        type: Number,
-        required: true,
-    },
-    lng: {
-        type: Number,
-        required: true,
-    },
-});
+const props = defineProps({ lat: Number, lng: Number });
+const map = ref(null);
 
 onMounted(() => {
-    const map = L.map("map").setView([props.lat, props.lng], 15);
+    const leafletMap = L.map(map.value).setView([props.lat, props.lng], 15);
     L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
         attribution: "&copy; OpenStreetMap contributors",
-    }).addTo(map);
-    L.marker([props.lat, props.lng]).addTo(map);
+    }).addTo(leafletMap);
+    L.marker([props.lat, props.lng]).addTo(leafletMap);
 });
 </script>

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -1,21 +1,11 @@
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
-    <head>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-
-        <title inertia>{{ config('app.name', 'Laravel') }}</title>
-
-        <!-- Fonts -->
-        <link rel="preconnect" href="https://fonts.bunny.net">
-        <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
-
-        <!-- Scripts -->
-        @routes
-        @vite(['resources/js/app.js', "resources/js/Pages/{$page['component']}.vue"])
-        @inertiaHead
-    </head>
-    <body class="font-sans antialiased">
-        @inertia
-    </body>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>物件担当者割り当て管理アプリ</title>
+    @vite(['resources/js/app.js'], 'resources/css/app.css')
+</head>
+<body>
+    @inertia
+</body>
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,27 +1,13 @@
 <?php
 
-use App\Http\Controllers\ProfileController;
-use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
-use Inertia\Inertia;
+use App\Http\Controllers\PropertyController;
+use App\Http\Controllers\AgentController;
 
-Route::get('/', function () {
-    return Inertia::render('Welcome', [
-        'canLogin' => Route::has('login'),
-        'canRegister' => Route::has('register'),
-        'laravelVersion' => Application::VERSION,
-        'phpVersion' => PHP_VERSION,
-    ]);
-});
+// Inertiaページとしてルーティング
+Route::get('/', [PropertyController::class, 'index'])->name('home');
+Route::resource('properties', PropertyController::class)->except(['show']);
+Route::get('properties/{property}', [PropertyController::class, 'show'])->name('properties.show');
 
-Route::get('/dashboard', function () {
-    return Inertia::render('Dashboard');
-})->middleware(['auth', 'verified'])->name('dashboard');
-
-Route::middleware('auth')->group(function () {
-    Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
-    Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
-    Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
-});
-
-require __DIR__.'/auth.php';
+Route::resource('agents', AgentController::class)->except(['show']);
+Route::get('agents/{agent}', [AgentController::class, 'show'])->name('agents.show');


### PR DESCRIPTION
以下の初期セットアップを実装しました。

---

-  **ルーティング設定（routes/web.php）にPropertyとAgentのルートを追加**
-  **PropertyControllerにInertiaレスポンスを実装し、データ取得とVueページへの受け渡しを対応**
-  **Vueページコンポーネントを作成**
  　**- 物件一覧ページ（Properties/Index.vue）**
  　**- 物件詳細ページ（Properties/Show.vue）と地図コンポーネント（PropertyMap.vue）**
-  **Inertia用のBladeテンプレート（resources/views/app.blade.php）を追加し、Viteでのビルド設定を組み込み**
-  **app.jsでInertia + Vueアプリケーションの起動設定を実装**

 
---

これにより、Laravel + Inertia + Vueの基本的な画面表示が可能になりました。
