### PR TITLE
feat: 担当者割り当て機能の改善およびエージェント・物件のCRUDページを追加

### DIFF
--- a/resources/js/Pages/Agents/Create.vue
+++ b/resources/js/Pages/Agents/Create.vue
@@ -1,0 +1,47 @@
+<script setup>
+import { useForm } from "@inertiajs/inertia-vue3";
+
+const form = useForm({
+    name: "",
+    email: "",
+});
+
+const submit = () => {
+    form.post(route("agents.store"));
+};
+</script>
+
+<template>
+    <div>
+        <h1>新規担当社登録</h1>
+        <form @submit.prevent="submit">
+            <div>
+                <label>名前</label>
+                <input
+                    v-model="form.name"
+                    type="text"
+                    class="form-control"
+                    required
+                />
+                <div v-if="form.errors.name" style="color: red">
+                    {{ form.errors.name }}
+                </div>
+            </div>
+
+            <div>
+                <label>Email</label>
+                <input
+                    v-model="form.email"
+                    type="email"
+                    class="form-control"
+                    required
+                />
+                <div v-if="form.errors.email" style="color: red">
+                    {{ form.errors.email }}
+                </div>
+            </div>
+
+            <button type="submit" :disabled="form.processing">登録</button>
+        </form>
+    </div>
+</template>

--- a/resources/js/Pages/Agents/Edit.vue
+++ b/resources/js/Pages/Agents/Edit.vue
@@ -1,0 +1,58 @@
+<script setup>
+import { useForm } from "@inertiajs/inertia-vue3";
+
+const props = defineProps({
+    agent: Object,
+});
+
+const form = useForm({
+    name: props.agent.name,
+    email: props.agent.email,
+});
+
+const submit = () => {
+    form.put(route("agent.update", props.agent.id));
+};
+</script>
+
+<template>
+    <div>
+        <h1>担当者編集</h1>
+        <form @submit.prevent="submit">
+            <div>
+                <label>名前</label>
+                <input
+                    v-model="form.name"
+                    type="text"
+                    class="form-control"
+                    required
+                />
+                <div v-if="form.errors.name" style="color: red">
+                    {{ form.errors.name }}
+                </div>
+            </div>
+
+            <div>
+                <label>Email</label>
+                <input
+                    v-model="form.email"
+                    type="email"
+                    class="form-control"
+                    required
+                />
+                <div v-if="form.errors.email" style="color: red">
+                    {{ form.errors.email }}
+                </div>
+            </div>
+
+            <button
+                type="submit"
+                class="btn btn-primary"
+                :disabled="form.processing"
+            >
+                更新
+            </button>
+            <Link href="/agents">一覧へ戻る</Link>
+        </form>
+    </div>
+</template>

--- a/resources/js/Pages/Agents/Index.vue
+++ b/resources/js/Pages/Agents/Index.vue
@@ -1,0 +1,39 @@
+<script setup>
+import { Link } from "@inertiajs/vue3";
+const props = defineProps({
+    agents: Array,
+});
+</script>
+
+<template>
+    <div>
+        <h1>担当者一覧</h1>
+        <Link href="/agents/create" class="btn btn-primary mb-2"
+            >新規担当者登録</Link
+        >
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>名前</th>
+                    <th>Email</th>
+                    <th>編集</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr v-for="ag in agents" :key="agent.id">
+                    <td>{{ a.id }}</td>
+                    <td>{{ a.name }}</td>
+                    <td>{{ a.email }}</td>
+                    <td>
+                        <Link
+                            :href="`/agents/${a.id}/edit`"
+                            class="btn btn-warning btn-sm"
+                            >編集</Link
+                        >
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</template>

--- a/resources/js/Pages/Agents/Show.vue
+++ b/resources/js/Pages/Agents/Show.vue
@@ -1,0 +1,15 @@
+<script setup>
+const props = defineProps({
+    agent: Object,
+});
+</script>
+
+<template>
+    <div>
+        <h1>担当者詳細</h1>
+        <p><strong>ID:</strong> {{ agent.id }}</p>
+        <p><strong>名前:</strong> {{ agent.name }}</p>
+        <p><strong>Email:</strong> {{ agent.email }}</p>
+    </div>
+    <Link href="/agents">一覧へ戻る</Link>
+</template>

--- a/resources/js/Pages/Properties/Create.vue
+++ b/resources/js/Pages/Properties/Create.vue
@@ -1,0 +1,73 @@
+<script setup>
+import { useForm } from "@inertiajs/inertia-vue3";
+
+const form = useForm({
+    name: "",
+    address: "",
+    latitude: "",
+    longitude: "",
+});
+
+const submit = () => {
+    form.post(route("properties.store"));
+};
+</script>
+
+<template>
+    <div>
+        <h1>物件登録</h1>
+
+        <form @submit.prevent="submit">
+            <div class="mb-3">
+                <label>物件名</label>
+                <input
+                    v-model="form.name"
+                    type="text"
+                    class="form-control"
+                    required
+                />
+                <div v-if="form.errors.name" style="color: red">
+                    {{ form.errors.name }}
+                </div>
+            </div>
+
+            <div class="mb-3">
+                <label>住所</label>
+                <input
+                    v-model="form.address"
+                    type="text"
+                    class="form-control"
+                />
+                <div v-if="form.errors.address" style="color: red">
+                    {{ form.errors.address }}
+                </div>
+            </div>
+
+            <div class="mb-3">
+                <label>緯度</label>
+                <input
+                    v-model="form.latitude"
+                    type="text"
+                    class="form-control"
+                />
+                <div v-if="form.errors.latitude" style="color: red">
+                    {{ form.errors.latitude }}
+                </div>
+            </div>
+
+            <div class="mb-3">
+                <label>経度</label>
+                <input
+                    v-model="form.longitude"
+                    type="text"
+                    class="form-control"
+                />
+                <div v-if="form.errors.longitude" style="color: red">
+                    {{ form.errors.longitude }}
+                </div>
+            </div>
+
+            <button type="submit" class="btn btn-primary">登録</button>
+        </form>
+    </div>
+</template>

--- a/resources/js/Pages/Properties/Edit.vue
+++ b/resources/js/Pages/Properties/Edit.vue
@@ -1,0 +1,86 @@
+<script setup>
+import { useForm } from "@inertiajs/inertia-vue3";
+import { defineProps } from "vue";
+
+const props = defineProps({
+    Property: Object,
+});
+
+const form = useForm({
+    name: props.property.name,
+    address: props.property.address,
+    latitude: props.property.latitude,
+    longitude: props.property.longitude,
+});
+
+const submit = () => {
+    form.put(route("properties.update", props.property.id));
+};
+</script>
+
+<template>
+    <div>
+        <h1>物件編集</h1>
+
+        <form @submit.prevent="submit">
+            <div class="mb-3">
+                <label>物件名</label>
+                <input
+                    v-model="form.name"
+                    type="text"
+                    class="form-control"
+                    required
+                />
+                <div v-if="form.errors.name" style="color: red">
+                    {{ form.errors.name }}
+                </div>
+            </div>
+
+            <div class="mb-3">
+                <label>住所</label>
+                <input
+                    v-model="form.address"
+                    type="text"
+                    class="form-control"
+                />
+
+                <div v-if="form.errors.address" style="color: red">
+                    {{ form.errors.address }}
+                </div>
+            </div>
+
+            <div class="mb-3">
+                <label>緯度</label>
+                <input
+                    v-model="form.latitude"
+                    type="text"
+                    class="form-control"
+                />
+                <div v-if="form.errors.latitude" style="color: red">
+                    {{ form.errors.latitude }}
+                </div>
+            </div>
+
+            <div class="mb-3">
+                <label>経度</label>
+                <input
+                    v-model="form.longitude"
+                    type="text"
+                    class="form-control"
+                />
+                <div v-if="form.errors.longitude" style="color: red">
+                    {{ form.errors.longitude }}
+                </div>
+            </div>
+
+            <button
+                type="submit"
+                class="btn btn-primary"
+                :disabled="form.processing"
+            >
+                更新
+            </button>
+            <Link href="/properties">一覧へ戻る</Link>
+        </form>
+    </div>
+</template>

--- a/resources/js/Pages/Properties/Index.vue
+++ b/resources/js/Pages/Properties/Index.vue
@@ -1,0 +1,33 @@
+<script setup>
+import { Link } from "@inertiajs/inertia-vue3";
+defineProps({ properties: Array });
+</script>
+
+<template>
+    <div>
+        <h1>物件一覧</h1>
+        <Link href="/properties/create" class="btn btn-primary mb-2"
+            >新規物件登録</Link
+        >
+        <table>
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>物件名</th>
+                    <th>住所</th>
+                    <th>地図</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr v-for="p in properties" :key="p.id">
+                    <td>{{ p.id }}</td>
+                    <td>{{ p.name }}</td>
+                    <td>{{ p.address }}</td>
+                    <td>
+                        <Link :href="route('properties.show', p.id)">詳細</Link>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</template>

--- a/resources/js/Pages/Properties/Show.vue
+++ b/resources/js/Pages/Properties/Show.vue
@@ -1,0 +1,30 @@
+<script setup>
+import AgentAssign from "@components/AgentAssign.vue";
+import PropertyMap from "@components/PropertyMap.vue";
+import { Link } from "@inertiajs/inertia-vue3";
+
+const props = defineProps({
+    property: Object,
+});
+</script>
+
+<template>
+    <div>
+        <h2>{{ property.name }}</h2>
+        <p>住所: {{ property.address }}</p>
+        <p>緯度: {{ property.latitude }}, 経度: {{ property.longitude }}</p>
+        <PropertyMap
+            v-if="property.latitude && property.longitude"
+            :lat="property.latitude"
+            :lng="property.longitude"
+        />
+
+        <h3>担当者</h3>
+        <ul>
+            <li v-for="a in property.agents" :key="a.id">
+                <AgentAssign :agent="a" :property-id="property.id" />
+            </li>
+        </ul>
+        <Link href="/properties">一覧へ戻る</Link>
+    </div>
+</template>

--- a/resources/js/components/AgentAssign.vue
+++ b/resources/js/components/AgentAssign.vue
@@ -6,58 +6,114 @@ const props = defineProps({
     agents: Array,
 });
 
-const agentList = ref(props.agents);
-const allAgents = ref([]);
-const selectedAgentId = ref(null);
+const agentList = ref([...props.agents]); // 担当済みリスト
+const allAgents = ref([]); // 全担当者リスト
+const selectedAgentId = ref(null); // セレクトボックスで選んだID
 
 onMounted(async () => {
-    // 全担当者取得
-    const res = await fetch("/api/agents");
-    allAgents.value = await res.json();
+    try {
+        const res = await fetch("/api/agents");
+        if (!res.ok) throw new Error("担当者の取得に失敗しました");
+        allAgents.value = await res.json();
+    } catch (e) {
+        console.error(e);
+    }
 });
 
+// 担当者を物件に割り当て
 const assign = async () => {
-    await fetch(`/api/properties/${props.propertyId}/assign`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ agent_id: selectedAgentId.value }),
-    });
-    // UI更新（本番は再取得推奨）
-    agentList.value.push(
-        allAgents.value.find((a) => a.id === selectedAgentId.value)
-    );
+    if (!selectedAgentId.value) return;
+
+    try {
+        const res = await fetch(`/api/properties/${props.propertyId}/assign`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Accept: "application/json",
+            },
+            body: JSON.stringify({ agent_id: selectedAgentId.value }),
+        });
+
+        if (!res.ok) throw new Error("割り当てに失敗しました");
+
+        const assignedAgent = allAgents.value.find(
+            (a) => a.id === selectedAgentId.value
+        );
+
+        if (
+            assignedAgent &&
+            !agentList.value.some((a) => a.id === assignedAgent.id)
+        ) {
+            agentList.value.push(assignedAgent);
+        }
+
+        selectedAgentId.value = null; // リセット
+    } catch (e) {
+        console.error(e);
+    }
 };
 
+// 担当者の割り当て解除
 const unassign = async (agentId) => {
-    await fetch(`/api/properties/${props.propertyId}/unassign`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ agent_id: agentId }),
-    });
-    agentList.value = agentList.value.filter((a) => a.id !== agentId);
+    try {
+        const res = await fetch(
+            `/api/properties/${props.propertyId}/unassign`,
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Accept: "application/json",
+                },
+                body: JSON.stringify({ agent_id: agentId }),
+            }
+        );
+
+        if (!res.ok) throw new Error("解除に失敗しました");
+
+        agentList.value = agentList.value.filter((a) => a.id !== agentId);
+    } catch (e) {
+        console.error(e);
+    }
 };
 </script>
 
 <template>
     <div>
-        <h4>担当者一覧</h4>
-        <ul>
-            <li v-for="agent in agentList" :key="agent.id">
-                {{ agent.name }} ({{ agent.email }})
-                <button @click="unassign(agent.id)">解除</button>
+        <h4 class="font-bold mb-2">担当者一覧</h4>
+        <ul class="mb-4">
+            <li
+                v-for="agent in agentList"
+                :key="agent.id"
+                class="flex items-center justify-between mb-1"
+            >
+                <span>{{ agent.name }} ({{ agent.email }})</span>
+                <button
+                    @click="unassign(agent.id)"
+                    class="text-red-500 text-sm"
+                >
+                    解除
+                </button>
             </li>
         </ul>
 
-        <h5>担当者割り当て</h5>
-        <select v-model="selectedAgentId">
-            <option
-                v-for="agent in allAgents"
-                :key="agent.id"
-                :value="agent.id"
+        <h5 class="font-semibold mb-1">担当者を追加</h5>
+        <div class="flex items-center gap-2">
+            <select v-model="selectedAgentId" class="border rounded px-2 py-1">
+                <option disabled value="">-- 担当者を選択 --</option>
+                <option
+                    v-for="agent in allAgents"
+                    :key="agent.id"
+                    :value="agent.id"
+                >
+                    {{ agent.name }}
+                </option>
+            </select>
+            <button
+                @click="assign"
+                class="bg-blue-500 text-white px-3 py-1 rounded"
             >
-                {{ agent.name }}
-            </option>
-        </select>
-        <button @click="assign">割り当て</button>
+                割り当て
+            </button>
+        </div>
     </div>
 </template>

--- a/resources/views/layouts/AppLayout.vue
+++ b/resources/views/layouts/AppLayout.vue
@@ -1,0 +1,8 @@
+<template>
+    <div>
+        <header>ナビゲーションなど</header>
+        <main>
+            <slot />
+        </main>
+    </div>
+</template>


### PR DESCRIPTION
**概要**
---

以下のVueコンポーネントを作成・実装し、担当者割り当て機能の改善もあわせて行いました。全体として、Inertia + Vueベースのフロントエンド構築を進める対応です。

---
**🔧 変更内容**
---
✅ 担当者割り当て機能の改善 (AgentAssign.vue)
- API通信時のエラーハンドリングを追加（try-catch）
- すでに割り当て済みの担当者を重複追加しないよう制御
- 選択状態リセットを追加
- UIの整理（Tailwind CSSによるボタン・セレクトのスタイル調整）

✅ エージェント（担当者）関連ページを作成
`resources/js/Pages/Agents/Index.vue`

`resources/js/Pages/Agents/Create.vue`

`resources/js/Pages/Agents/Edit.vue`

`resources/js/Pages/Agents/Show.vue`

✅ 物件（Properties）関連ページを作成
`resources/js/Pages/Properties/Index.vue`

`resources/js/Pages/Properties/Create.vue`

`resources/js/Pages/Properties/Edit.vue`

`resources/js/Pages/Properties/Show.vue`

✅ レイアウトコンポーネントの作成

- 共通レイアウト AppLayout.vue を作成

各ページにてInertia経由でレイアウトを適用

---

**💡 技術的補足**
---
- 各ページはInertia.jsのルーティングに対応し、resolvePageComponent を通じて動的に読み込まれます。
- defineProps() を活用し、各ページ/コンポーネントで型付きPropsを明示。